### PR TITLE
Fix board path parameters in post endpoints

### DIFF
--- a/app/schemas/post.py
+++ b/app/schemas/post.py
@@ -54,7 +54,7 @@ class PostUpdate(BaseModel):
     """게시글 부분 수정 요청 (모든 필드 Optional)"""
     title: Optional[str] = Field(None, max_length=255)
     content: Optional[str] = None
-    board_id: int  # 게시판 지정 추가!
+    board_id: Optional[int] = None  # 게시판 지정 추가!
 
 
 # 응답(Response)


### PR DESCRIPTION
## Summary
- use board_id parameter from URL in post routes
- allow optional board_id in `PostUpdate`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7f073b7c832e8828b1298f9d3d19