### PR TITLE
Add boards listing endpoint

### DIFF
--- a/app/api/v1/endpoints/board.py
+++ b/app/api/v1/endpoints/board.py
@@ -18,3 +18,8 @@ def create_board(payload: BoardCreate, db: Session = Depends(get_db)):
 @router.get("/", response_model=list[BoardOut])
 def get_boards(db: Session = Depends(get_db)):
     return db.query(Board).all()
+
+
+@router.get("/all_boards", response_model=list[BoardOut])
+def list_all_boards(db: Session = Depends(get_db)):
+    return db.query(Board).all()

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from .endpoints  import auth, users, posts, comments, files, ws
+from .endpoints  import auth, users, posts, comments, files, ws, board
 
 api_router = APIRouter()
 
@@ -25,6 +25,13 @@ api_router.include_router(
     posts.router,
     prefix="/posts",
     tags=["Posts"],
+)
+
+# Board routes (/api/v1/boards)
+api_router.include_router(
+    board.router,
+    prefix="/boards",
+    tags=["Boards"],
 )
 
 # Comment & Reply routes

--- a/app/schemas/board.py
+++ b/app/schemas/board.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 class BoardBase(BaseModel):
@@ -9,6 +10,7 @@ class BoardCreate(BoardBase):
 
 class BoardOut(BoardBase):
     id: int
+    created_at: datetime
 
     class Config:
         orm_mode = True

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -41,8 +41,8 @@ app.dependency_overrides[get_db] = override_get_db
 client = TestClient(app)
 
 
-def create_board(db):
-    board = Board(name="general", description="test board")
+def create_board(db, name="general"):
+    board = Board(name=name, description="test board")
     db.add(board)
     db.commit()
     db.refresh(board)
@@ -87,3 +87,16 @@ def test_create_post():
     r = client.get(f"/api/v1/posts/boards/{board_id}/posts/{post_id}")
     assert r.status_code == 200
     assert r.json()["title"] == "Hello"
+
+
+def test_get_all_boards():
+    # ensure at least one board exists
+    with TestingSessionLocal() as db:
+        board = create_board(db, name="general2")
+        name = board.name
+
+    r = client.get("/api/v1/boards/all_boards")
+    assert r.status_code == 200
+    data = r.json()
+    assert any(b["name"] == name for b in data)
+    assert "created_at" in data[0]


### PR DESCRIPTION
## Summary
- expose board router in API router
- support `created_at` field in board output schema
- add `/api/v1/boards/all_boards` endpoint
- test the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685016405e8c832e8df5fc863de12f1d