### PR TITLE
Add boards post count

### DIFF
--- a/README.websocket.md
+++ b/README.websocket.md
@@ -29,7 +29,7 @@ uvicorn app.main:app --reload
   <div id="messages"></div>
 
   <script>
-    const roomId = "general"; // 방 이름
+    const roomId = "board_id_1"; // 게시판 ID 기반 방 이름
     const username = prompt("이름 입력:");
     const ws = new WebSocket(`ws://localhost:8000/api/v1/ws/chat/${roomId}?username=${username}`);
 
@@ -61,7 +61,7 @@ uvicorn app.main:app --reload
 ![image](https://github.com/user-attachments/assets/86d22c6a-b4c3-4c82-955a-cb0ab5c6036f)
 
 ```bash
-./websocat.x86_64-unknown-linux-musl  ws://localhost:8000/api/v1/ws/chat/general?username=alice
+./websocat.x86_64-unknown-linux-musl  ws://localhost:8000/api/v1/ws/chat/board_id_2?username=alice
 ```
 
 새 터미널을 열어 다른 사용자로 접속 후 메시지를 입력하면 서로의 메시지가 실시간으로 전달되는 것을 확인할 수 있습니다.

--- a/app/api/v1/endpoints/board.py
+++ b/app/api/v1/endpoints/board.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 from app.api.deps import get_db
 from app.schemas.board import BoardCreate, BoardOut
 from app.db.models.board import Board
+from app.db.models.post import Post
 
 router = APIRouter()
 
@@ -13,8 +15,56 @@ def create_board(payload: BoardCreate, db: Session = Depends(get_db)):
     db.add(board)
     db.commit()
     db.refresh(board)
-    return board
+    return BoardOut(
+        id=board.id,
+        name=board.name,
+        description=board.description,
+        posts=0,
+        created_at=board.created_at,
+        room_name=board.room_name,
+    )
 
 @router.get("/", response_model=list[BoardOut])
 def get_boards(db: Session = Depends(get_db)):
-    return db.query(Board).all()
+    results = (
+        db.query(Board, func.count(Post.id).label("posts"))
+        .outerjoin(Post, Board.id == Post.board_id)
+        .group_by(Board.id)
+        .all()
+    )
+    boards = []
+    for board, posts in results:
+        boards.append(
+            BoardOut(
+                id=board.id,
+                name=board.name,
+                description=board.description,
+                posts=posts,
+                created_at=board.created_at,
+                room_name=board.room_name,
+            )
+        )
+    return boards
+
+
+@router.get("/all_boards", response_model=list[BoardOut])
+def list_all_boards(db: Session = Depends(get_db)):
+    results = (
+        db.query(Board, func.count(Post.id).label("posts"))
+        .outerjoin(Post, Board.id == Post.board_id)
+        .group_by(Board.id)
+        .all()
+    )
+    boards = []
+    for board, posts in results:
+        boards.append(
+            BoardOut(
+                id=board.id,
+                name=board.name,
+                description=board.description,
+                posts=posts,
+                created_at=board.created_at,
+                room_name=board.room_name,
+            )
+        )
+    return boards

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from .endpoints  import auth, users, posts, comments, files, ws
+from .endpoints  import auth, users, posts, comments, files, ws, board
 
 api_router = APIRouter()
 
@@ -25,6 +25,13 @@ api_router.include_router(
     posts.router,
     prefix="/posts",
     tags=["Posts"],
+)
+
+# Board routes (/api/v1/boards)
+api_router.include_router(
+    board.router,
+    prefix="/boards",
+    tags=["Boards"],
 )
 
 # Comment & Reply routes

--- a/app/db/models/board.py
+++ b/app/db/models/board.py
@@ -29,3 +29,8 @@ class Board(Base):
 
     def __repr__(self):
         return f"<Board id={self.id} name={self.name!r}>"
+
+    @property
+    def room_name(self) -> str:
+        """Room name for WebSocket chat."""
+        return f"board_id_{self.id}"

--- a/app/db/models/file.py
+++ b/app/db/models/file.py
@@ -71,6 +71,11 @@ class File(Base):
         lazy="joined",
     )
 
+    @property
+    def url(self) -> str:
+        """Download URL for the file."""
+        return f"/api/v1/files/{self.id}/download"
+
     # 메타데이터
     def __repr__(self) -> str:  # pragma: no cover
         return f"<File id={self.id} filename={self.filename!r}>"

--- a/app/schemas/board.py
+++ b/app/schemas/board.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 class BoardBase(BaseModel):
@@ -9,6 +10,9 @@ class BoardCreate(BoardBase):
 
 class BoardOut(BoardBase):
     id: int
+    posts: int
+    created_at: datetime
+    room_name: str
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/schemas/file.py
+++ b/app/schemas/file.py
@@ -10,10 +10,10 @@ from pydantic import BaseModel
 class FileOut(BaseModel):
     id: int
     filename: str
-    # url: str
+    url: str
     content_type: str
     size: int
     created_at: datetime
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/schemas/post.py
+++ b/app/schemas/post.py
@@ -32,7 +32,7 @@ class FileMeta(BaseModel):
     url: str
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 # 요청(Request) 
@@ -68,7 +68,7 @@ class PostOut(_PostBase):
     updated_at: datetime
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class PostListOut(BaseModel):
@@ -80,4 +80,4 @@ class PostListOut(BaseModel):
     created_at: datetime
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -41,7 +41,7 @@ def save_file(db: Session, file: UploadFile, post_id: int, uploader_id: int) -> 
     return FileOut(
         id=file_meta.id,
         filename=file_meta.filename,
-        # url=file_url,
+        url=f"/api/v1/files/{file_meta.id}/download",
         content_type=file_meta.content_type,
         size=file_meta.size,
         created_at=file_meta.created_at,


### PR DESCRIPTION
## Summary
- extend `BoardOut` schema with `posts` count
- include post counts when creating and listing boards
- verify `/api/v1/boards/all_boards` includes correct post totals
- add download URL to file responses
- ensure posts with attachments serialize correctly
- expose chat room names in board schema and docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685016405e8c832e8df5fc863de12f1d